### PR TITLE
add click to open folder where distro is installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # JDKMon
 
 JDKMon is a little tool written in JavaFX that tries to detect all JDK's installed
-on your machine. Dependending on the operating system it will try to find the JDK's
+on your machine. Depending on the operating system it will try to find the JDK's
 in the following folders:
 
 MacOS: `/System/Volumes/Data/Library/Java/JavaVirtualMachines/`

--- a/src/main/java/eu/hansolo/fx/jdkmon/Main.java
+++ b/src/main/java/eu/hansolo/fx/jdkmon/Main.java
@@ -661,6 +661,9 @@ public class Main extends Application {
         distroLabel.setAlignment(Pos.CENTER_LEFT);
         distroLabel.setMaxWidth(Double.MAX_VALUE);
 
+        distroLabel.setTooltip(new Tooltip(distribution.getLocation()));
+        distroLabel.setOnMouseReleased(e -> openDistribution(distribution));
+
         HBox hBox = new HBox(5, distroLabel);
         hBox.setMinWidth(360);
 
@@ -837,6 +840,14 @@ public class Main extends Application {
                 }
         });
         return hBox;
+    }
+
+    private void openDistribution(Distribution distribution) {
+        try {
+            Desktop.getDesktop().open(new File(distribution.getLocation()));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 
     private Dialog createAboutDialog() {

--- a/src/main/java/eu/hansolo/fx/jdkmon/Main.java
+++ b/src/main/java/eu/hansolo/fx/jdkmon/Main.java
@@ -662,7 +662,10 @@ public class Main extends Application {
         distroLabel.setMaxWidth(Double.MAX_VALUE);
 
         distroLabel.setTooltip(new Tooltip(distribution.getLocation()));
-        distroLabel.setOnMouseReleased(e -> openDistribution(distribution));
+        distroLabel.setOnMousePressed(e -> {
+            if (e.isPrimaryButtonDown())
+                openDistribution(distribution);
+        });
 
         HBox hBox = new HBox(5, distroLabel);
         hBox.setMinWidth(360);

--- a/src/main/java/eu/hansolo/fx/jdkmon/tools/Distribution.java
+++ b/src/main/java/eu/hansolo/fx/jdkmon/tools/Distribution.java
@@ -23,18 +23,16 @@ public class Distribution {
     private final String  operatingSystem;
     private final String  architecture;
     private final Boolean fxBundled;
+    private final String location;
 
-
-    public Distribution(final String name, final String apiString, final String version, final String operatingSystem, final String architecture) {
-        this(name, apiString, version, operatingSystem, architecture, null);
-    }
-    public Distribution(final String name, final String apiString, final String version, final String operatingSystem, final String architecture, final Boolean fxBundled) {
+    public Distribution(final String name, final String apiString, final String version, final String operatingSystem, final String architecture, final Boolean fxBundled, final String location) {
         this.name            = name;
         this.apiString       = apiString;
         this.version         = version;
         this.operatingSystem = operatingSystem;
         this.architecture    = architecture;
         this.fxBundled       = fxBundled;
+        this.location        = location;
     }
 
 
@@ -50,6 +48,7 @@ public class Distribution {
 
     public Boolean getFxBundled() { return fxBundled; }
 
+    public String getLocation() { return location; }
 
     @Override public String toString() {
         return new StringBuilder().append("{")
@@ -59,6 +58,7 @@ public class Distribution {
                                   .append("\"operating_system\":\"").append(getOperatingSystem()).append("\",")
                                   .append("\"architecture\":\"").append(getArchitecture()).append("\",")
                                   .append("\"fx\":\"").append(getFxBundled()).append("\"")
+                                  .append("\"location\":\"").append(getLocation()).append("\"")
                                   .append("}")
                                   .toString();
     }

--- a/src/main/java/eu/hansolo/fx/jdkmon/tools/Finder.java
+++ b/src/main/java/eu/hansolo/fx/jdkmon/tools/Finder.java
@@ -300,7 +300,7 @@ public class Finder {
                     }
                 }
 
-                distros.add(new Distribution(name, apiString, version.toString(OutputFormat.REDUCED_COMPRESSED, true, true), operatingSystem, architecture, fxBundled));
+                distros.add(new Distribution(name, apiString, version.toString(OutputFormat.REDUCED_COMPRESSED, true, true), operatingSystem, architecture, fxBundled, parentPath));
             });
             service.submit(streamer);
         } catch (IOException e) {


### PR DESCRIPTION
First of all, nice utility, when I first saw it I didn't think I'd have much use since sdkman kind of handles updates but then I realized I use Windows at work so this will be handy.

I wanted to be able to clean up some old distros so wanted a way to get to the install folder.

This kind of interferes with the context menu, not sure why, I'm still am not much of an javafx expert.

Also bonus typo fix.